### PR TITLE
Support draws between each players in AdjustSkillWithDraws method

### DIFF
--- a/trueskill.go
+++ b/trueskill.go
@@ -110,14 +110,11 @@ func New(opts ...Option) Config {
 	return c
 }
 
-// AdjustSkills returns the new skill level distribution for all provided
+// AdjustSkillsWithDraws returns the new skill level distribution for all provided
 // players based on game configuration and draw status.
-func (ts Config) AdjustSkills(players []Player, draw bool) (newSkills []Player, probability float64) {
-	draws := make([]bool, len(players)-1)
-	for i := range draws {
-		draws[i] = draw
-	}
-
+// For a N-player game, the draws parameter should have length n-1, where draws[i]
+// represents whether player[i] and player[i+1] are in draw.
+func (ts Config) AdjustSkillsWithDraws(players []Player, draws []bool) (newSkills []Player, probability float64) {
 	// TODO: Rewrite the distribution bag and simplify the factor list as well
 	prior := gaussian.NewFromPrecision(0, 0)
 	varBag := collection.NewDistributionBag(prior)
@@ -137,6 +134,20 @@ func (ts Config) AdjustSkills(players []Player, draw bool) (newSkills []Player, 
 	}
 
 	return newSkills, probability
+}
+
+// AdjustSkills returns the new skill level distribution for all provided
+// players based on game configuration and draw status.
+// This function can only accept draw as bool which means all players have the
+// same ranking. If you need to accept individual player draw state, please call
+// AdjustSkillWithDraws.
+func (ts Config) AdjustSkills(players []Player, draw bool) (newSkills []Player, probability float64) {
+	draws := make([]bool, len(players)-1)
+	for i := range draws {
+		draws[i] = draw
+	}
+
+	return ts.AdjustSkillsWithDraws(players, draws)
 }
 
 // MatchQuality returns a float representing the quality of the match-up

--- a/trueskill.go
+++ b/trueskill.go
@@ -115,6 +115,13 @@ func New(opts ...Option) Config {
 // For a N-player game, the draws parameter should have length n-1, where draws[i]
 // represents whether player[i] and player[i+1] are in draw.
 func (ts Config) AdjustSkillsWithDraws(players []Player, draws []bool) (newSkills []Player, probability float64) {
+	// panic if draws slice length is not as expected
+	if len(draws) != len(players)-1 {
+		panic(fmt.Sprintf(
+			"draws slice should have length %d but have %d instead",
+			len(players)-1, len(draws)))
+	}
+
 	// TODO: Rewrite the distribution bag and simplify the factor list as well
 	prior := gaussian.NewFromPrecision(0, 0)
 	varBag := collection.NewDistributionBag(prior)

--- a/trueskill_test.go
+++ b/trueskill_test.go
@@ -186,7 +186,8 @@ func TestTrueSkill_4PFreeForAll_WithDraws(t *testing.T) {
 
 	ts := New(drawProbability)
 
-	players := []Player{ts.NewPlayer(),
+	players := []Player{
+		ts.NewPlayer(),
 		ts.NewPlayer(),
 		ts.NewPlayer(),
 		ts.NewPlayer()}

--- a/trueskill_test.go
+++ b/trueskill_test.go
@@ -6,9 +6,10 @@ import (
 	"github.com/mafredri/go-trueskill/mathextra"
 )
 
-const epsilon = 1e-5 // Precision for floating point comparison
+const defaultEpsilon = 1e-5 // Precision for floating point comparison
 
-func testPlayerSkills(t *testing.T, playerSkills []Player, wantSkill []float64) {
+func testPlayerSkillsWithErrorMargin(
+	t *testing.T, playerSkills []Player, wantSkill []float64, epsilon float64) {
 	for i, p := range playerSkills {
 		if !mathextra.Float64AlmostEq(p.Mu(), wantSkill[i*2], epsilon) {
 			t.Errorf("p%d.Mu() == %.5f, want %.5f", i, p.Mu(), wantSkill[i*2])
@@ -19,9 +20,13 @@ func testPlayerSkills(t *testing.T, playerSkills []Player, wantSkill []float64) 
 	}
 }
 
+func testPlayerSkills(t *testing.T, playerSkills []Player, wantSkills []float64) {
+	testPlayerSkillsWithErrorMargin(t, playerSkills, wantSkills, defaultEpsilon)
+}
+
 func testProbability(t *testing.T, probability, wantProbability float64) {
 	probability = probability * 100
-	if !mathextra.Float64AlmostEq(probability, wantProbability, epsilon) {
+	if !mathextra.Float64AlmostEq(probability, wantProbability, defaultEpsilon) {
 		t.Errorf("Probability == %.5f, want %.5f", probability, wantProbability)
 	}
 }
@@ -156,6 +161,42 @@ func TestTrueSkill_4PFreeForAll(t *testing.T) {
 	newPlayerSkills, probability := ts.AdjustSkills(players, draw)
 
 	testPlayerSkills(t, newPlayerSkills, wantSkill)
+	testProbability(t, probability, wantProbability)
+}
+
+func TestTrueSkill_4PFreeForAll_WithDraws(t *testing.T) {
+	wantSkill := []float64{
+		28.162, 5.712,
+		28.162, 5.712,
+		21.836, 5.712,
+		21.836, 5.712,
+	}
+	wantProbability := 0.09406
+
+	drawProbability, err := DrawProbability(10.0)
+	if err != nil {
+		t.Error(err)
+	}
+
+	draws := []bool{
+		true,
+		false,
+		true,
+	}
+
+	ts := New(drawProbability)
+
+	players := []Player{ts.NewPlayer(),
+		ts.NewPlayer(),
+		ts.NewPlayer(),
+		ts.NewPlayer()}
+
+	newPlayerSkills, probability := ts.AdjustSkillsWithDraws(players, draws)
+
+	// In draw, the skill calculation for two drawed players are not guaranteed
+	// to be the same, but should be close. We gives a larger epsilon here as
+	// the error margin
+	testPlayerSkillsWithErrorMargin(t, newPlayerSkills, wantSkill, 0.01)
 	testProbability(t, probability, wantProbability)
 }
 


### PR DESCRIPTION
Hi mafewdri, 

The trueskill library you had is really awesome! 

I'd like to help adding one additional method in addition to the current AdjustSkill method, which currently only support draw as a bool, which means all players are in draw.

However, in buildSkillFactors function, it already supports a draws slice as parameter, so I just added a method on TrueSkill config to expose this functionality.

I am really new to Github, please let me know if I'm doing it wrong.